### PR TITLE
Add basic widget tests and widget chrome/title behavior

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -14,6 +14,8 @@ CommandDashboard.events.bind = function bindEvents(ui) {
 
     ui.dashboard.addEventListener("click", controllers.onDashboardClick);
     ui.dashboard.addEventListener("input", controllers.onDashboardInput);
+    ui.dashboard.addEventListener("keydown", controllers.onWidgetTitleKeyDown);
+    ui.dashboard.addEventListener("focusout", controllers.onWidgetTitleFocusOut);
 
     ui.clearNotesBtn.addEventListener("click", controllers.onClearNotes);
 

--- a/src/js/handlers/handlers.note.js
+++ b/src/js/handlers/handlers.note.js
@@ -3,13 +3,11 @@ window.CommandDashboard = window.CommandDashboard ?? {};
 CommandDashboard.handlers = CommandDashboard.handlers ?? {};
 console.log("Note widget handlers loaded");
 
-CommandDashboard.handlers["note-delete"] = function noteDeleteHandler({ widgetId }) {
+function _deleteWidget(widgetId) {
     if (!widgetId) return;
 
     let deletedWidget = null;
     let deleteIndex = -1;
-
-    deletedWidget = structuredClone(window.appState.widgets[deleteIndex]);
 
     CommandDashboard.store.apply(state => {
         deleteIndex = state.widgets.findIndex(w => w.id === widgetId);
@@ -17,67 +15,80 @@ CommandDashboard.handlers["note-delete"] = function noteDeleteHandler({ widgetId
 
         deletedWidget = structuredClone(state.widgets[deleteIndex]);
         state.widgets.splice(deleteIndex, 1);
-  });
-
-  if (deleteIndex === -1 || !deletedWidget) return;
-
-  const undoAction = {
-    actionText: "Undo",
-    onAction: () => {
-      CommandDashboard.store.apply(state => {
-        const i = Math.min(deleteIndex, state.widgets.length);
-        state.widgets.splice(i, 0, deletedWidget);
-      });
-      CommandDashboard.render.focusNote(deletedWidget.id);
-    }
-  };
-
-  CommandDashboard.toast.show("Note Deleted", "info", 5000, undoAction);
-};
-
-CommandDashboard.handlers["note-pin"] = function notePinHandler({ widgetId }) {
-    if (!widgetId) return;
-    
-    CommandDashboard.store.apply(state => {
-        const fromIndex = state.widgets.findIndex(w => w.id === widgetId);
-        if (fromIndex === -1) return;
-
-        const noteWidget = state.widgets[fromIndex];
-
-        if (CommandDashboard.widgets.meta.getPinned(noteWidget)) return;
-
-        state.widgets.splice(fromIndex, 1);
-
-        CommandDashboard.widgets.meta.setPinned(noteWidget, true);
-        state.widgets.splice(0, 0, noteWidget);
     });
-    
-    CommandDashboard.render.focusNote(widgetId);
-};
 
-CommandDashboard.handlers["note-unpin"] = function noteUnpinHandler({ widgetId}) {
+    if (deleteIndex === -1 || !deletedWidget) return;
+
+    const undoAction = {
+        actionText: "Undo",
+        onAction: () => {
+            CommandDashboard.store.apply(state => {
+                const i = Math.min(deleteIndex, state.widgets.length);
+                state.widgets.splice(i, 0, deletedWidget);
+            });
+            if (deletedWidget.type === "note") {
+                CommandDashboard.render.focusNote(deletedWidget.id);
+            }
+        }
+    };
+
+    CommandDashboard.toast.show("Widget Deleted", "info", 5000, undoAction);
+}
+
+function _pinWidget(widgetId, pin) {
     if (!widgetId) return;
 
     CommandDashboard.store.apply(state => {
         const fromIndex = state.widgets.findIndex(w => w.id === widgetId);
         if (fromIndex === -1) return;
 
-        const noteWidget = state.widgets[fromIndex];
-
-        if (!CommandDashboard.widgets.meta.getPinned(noteWidget)) return;
+        const widget = state.widgets[fromIndex];
+        const isPinned = CommandDashboard.widgets.meta.getPinned(widget);
+        if (pin === isPinned) return;
 
         state.widgets.splice(fromIndex, 1);
+
+        CommandDashboard.widgets.meta.setPinned(widget, pin);
+
+        if (pin) {
+            state.widgets.splice(0, 0, widget);
+            return;
+        }
 
         let insertIndex = 0;
         while (insertIndex < state.widgets.length) {
-            const widget = state.widgets[insertIndex];
-            if (!CommandDashboard.widgets.meta.getPinned(widget)) break;
+            const current = state.widgets[insertIndex];
+            if (!CommandDashboard.widgets.meta.getPinned(current)) break;
             insertIndex++;
         }
-        CommandDashboard.widgets.meta.setPinned(noteWidget, false);
-
-        state.widgets.splice(insertIndex, 0, noteWidget);
+        state.widgets.splice(insertIndex, 0, widget);
     });
 
     CommandDashboard.render.focusNote(widgetId);
+}
+
+CommandDashboard.handlers["widget-delete"] = function widgetDeleteHandler({ widgetId }) {
+    _deleteWidget(widgetId);
+};
+
+CommandDashboard.handlers["widget-pin-toggle"] = function widgetPinToggleHandler({ widgetId }) {
+    if (!widgetId) return;
+
+    const widget = window.appState.widgets.find(w => w.id === widgetId);
+    if (!widget) return;
+
+    const pinned = CommandDashboard.widgets.meta.getPinned(widget);
+    _pinWidget(widgetId, !pinned);
+};
+
+CommandDashboard.handlers["note-delete"] = function noteDeleteHandler({ widgetId }) {
+    _deleteWidget(widgetId);
+};
+
+CommandDashboard.handlers["note-pin"] = function notePinHandler({ widgetId }) {
+    _pinWidget(widgetId, true);
+};
+
+CommandDashboard.handlers["note-unpin"] = function noteUnpinHandler({ widgetId }) {
+    _pinWidget(widgetId, false);
 };

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -83,7 +83,7 @@ CommandDashboard.render.renderApp = function renderApp(state) {
         _dashboard.appendChild(widgetElement);
         const textarea = widgetElement.querySelector?.("textarea.note-text");
 
-        _autosizeTextarea(textarea);
+        if (textarea) _autosizeTextarea(textarea);
     }
 };
 

--- a/src/js/widgets/chrome.js
+++ b/src/js/widgets/chrome.js
@@ -12,6 +12,8 @@ function _createHeader(widget) {
     const title = document.createElement("div");
     title.className = "widget-title";
     title.contentEditable = "true";
+    title.setAttribute("data-placeholder", "Untitled");
+    title.setAttribute("spellcheck", "false");
     title.dataset.widgetId = widget.id;
     title.dataset.action = "widget-title";
     title.textContent = CommandDashboard.widgets.meta?.getTitle

--- a/src/js/widgets/note.js
+++ b/src/js/widgets/note.js
@@ -3,47 +3,14 @@ window.CommandDashboard = window.CommandDashboard ?? {};
 CommandDashboard.widgets = CommandDashboard.widgets ?? {};
 console.log("note widget registry loaded");
 
-function _createNoteCard(widget) {
-    const noteCard = document.createElement("div");
-    noteCard.className = "note-card";
-    
-    // Pinned or not, false if null
-    const pinned = CommandDashboard.widgets.meta.getPinned(widget);
-    if (pinned) noteCard.classList.add("is-pinned");
-
-    const header = document.createElement("div");
-    header.className = "note-card-header";
-
-    const pinBtn = document.createElement("button");
-    pinBtn.className = "note-pin"
-    pinBtn.type = "button";
-    pinBtn.textContent = pinned ? "📍" : "📌";
-    pinBtn.title = pinned ? "Unpin note" : "Pin note";
-    pinBtn.dataset.widgetId = widget.id;
-    pinBtn.dataset.action = pinned ? "note-unpin" : "note-pin";
-
-    header.appendChild(pinBtn);
-
-    const delBtn = document.createElement("button");
-    delBtn.className = "note-delete";
-    delBtn.type = "button";
-    delBtn.textContent = "✕";
-    delBtn.title = "Delete note";
-    delBtn.dataset.widgetId = widget.id;
-    delBtn.dataset.action = "note-delete";
-
-    header.appendChild(delBtn);
-
+function _createNoteBody(widget) {
     const textarea = document.createElement("textarea");
     textarea.className = "note-text";
     textarea.value = widget.data?.text ?? "";
     textarea.placeholder = "Write something ...";
     textarea.dataset.widgetId = widget.id;
 
-    noteCard.appendChild(header);
-    noteCard.appendChild(textarea);
-
-    return noteCard;
+    return textarea;
 }
 
 CommandDashboard.widgets.register("note", {
@@ -53,5 +20,5 @@ CommandDashboard.widgets.register("note", {
         data: { text: "" },
         meta: { pinned: false }
     }),
-    render: (widget) => _createNoteCard(widget),
+    render: (widget) => _createNoteBody(widget),
 });

--- a/src/js/widgets/registry.js
+++ b/src/js/widgets/registry.js
@@ -25,8 +25,16 @@ CommandDashboard.widgets.renderWidget = function renderWidget(widget) {
         console.warn("No widget registered for type:", type, widget);
         return null;
     }
+    const content = api.render(widget);
+    if (!content) return null;
 
-    return api.render(widget);
+    const chrome = CommandDashboard.widgets.chrome?.create;
+    if (typeof chrome !== "function") return content;
+
+    const { outer, body } = chrome(widget);
+    if (body && content) body.appendChild(content);
+
+    return outer ?? content;
 }
 
 CommandDashboard.widgets.get = function get(type) {

--- a/src/js/widgets/widgetMeta.js
+++ b/src/js/widgets/widgetMeta.js
@@ -33,7 +33,7 @@ CommandDashboard.widgets.meta.getTitle = function getTitle(widget) {
 CommandDashboard.widgets.meta.setTitle = function setTitle(widget, title) {
     const meta = _ensureMeta(widget);
     if (!meta) return;
-    const normalized = String(title ?? "").trim();
+    const normalized = String(title ?? "").replace(/\s+/g, " ").trim();
     meta.title = normalized;
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -94,13 +94,44 @@ body {
   overflow: auto;
 }
 
-.note-card {
+.widget {
   padding: 0.5rem;
   margin-bottom: 0.75rem;
   background: #d8c7c7;
   border: 1px solid #000000;
   border-radius: 10px;
   position: relative;
+}
+
+.widget-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.widget-title {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.widget-title[contenteditable="true"] {
+  outline: none;
+}
+
+.widget-title:empty::before {
+  content: attr(data-placeholder);
+  color: #666;
+  font-style: italic;
+}
+
+.widget-pin,
+.widget-delete {
+  flex-shrink: 0;
 }
 
 .note-text {
@@ -120,13 +151,7 @@ body {
   font-style: italic;
 }
 
-.note-card-header {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 0.5rem;
-}
-
-.note-delete {
+.widget-delete {
   border: 1px solid #ccc;
   background: transparent;
   cursor: pointer;
@@ -138,12 +163,12 @@ body {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .note-card.is-pinned {
+  .widget.is-pinned {
     animation: none;
   }
 }
 
-.note-card.is-pinned {
+.widget.is-pinned {
   border-left: 4px solid #40f430; /* warm pin color */
   background: #3e9e21;
   border: 0px;
@@ -151,18 +176,18 @@ body {
   animation: pin-pop 120ms ease-out;
 }
 
-.note-pin {
+.widget-pin {
   font-size: 1.1rem;
   line-height: 1;
   cursor: pointer;
   opacity: 0.7;
 }
 
-.note-card.is-pinned .note-pin {
+.widget.is-pinned .widget-pin {
   opacity: 1;
 }
 
-.note-pin:hover {
+.widget-pin:hover {
   opacity: 1;
 }
 

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const assert = require("assert");
+
+global.window = globalThis;
+
+global.window.CommandDashboard = global.window.CommandDashboard ?? {};
+
+global.window.CommandDashboard.widgets = global.window.CommandDashboard.widgets ?? {};
+
+global.window.CommandDashboard.widgets.chrome = null;
+
+require("../src/js/widgets/widgetMeta.js");
+require("../src/js/widgets/registry.js");
+
+function testTitleNormalization() {
+    const widget = { meta: {} };
+    CommandDashboard.widgets.meta.setTitle(widget, "  Hello   world  ");
+    assert.strictEqual(widget.meta.title, "Hello world");
+}
+
+function testRenderWithoutChrome() {
+    const widget = { id: "w1", type: "plain" };
+    const content = { nodeType: "content" };
+    CommandDashboard.widgets.register("plain", {
+        render: () => content
+    });
+
+    const rendered = CommandDashboard.widgets.renderWidget(widget);
+    assert.strictEqual(rendered, content);
+}
+
+function testRenderWithChrome() {
+    let appended = null;
+    CommandDashboard.widgets.chrome = {
+        create: () => ({
+            outer: { nodeType: "outer" },
+            body: {
+                appendChild: (child) => {
+                    appended = child;
+                }
+            }
+        })
+    };
+
+    const widget = { id: "w2", type: "wrapped" };
+    const content = { nodeType: "content" };
+
+    CommandDashboard.widgets.register("wrapped", {
+        render: () => content
+    });
+
+    const rendered = CommandDashboard.widgets.renderWidget(widget);
+    assert.strictEqual(rendered.nodeType, "outer");
+    assert.strictEqual(appended, content);
+}
+
+function run() {
+    const tests = [
+        testTitleNormalization,
+        testRenderWithoutChrome,
+        testRenderWithChrome
+    ];
+
+    for (const test of tests) {
+        test();
+    }
+
+    console.log(`Ran ${tests.length} basic widget tests.`);
+}
+
+run();


### PR DESCRIPTION
### Motivation
- Provide a shared widget chrome (header) with editable titles and pin/delete controls so title/pin logic is widget-agnostic.
- Normalize and persist widget metadata such as `title` and `pinned` to avoid layout and data inconsistencies.
- Simplify widget implementations (e.g. `note`) to return only body content and let the chrome layer handle header UI and actions.
- Add a minimal test harness to exercise core widget logic without requiring a browser UI.

### Description
- Added `tests/basic.test.js` which registers simple widget renderers and verifies title normalization and chrome wrapping behavior using a Node-based harness.
- Implemented widget chrome in `src/js/widgets/chrome.js` with an editable `.widget-title`, pin/delete buttons, and used it in `CommandDashboard.widgets.renderWidget` to wrap renderer output.
- Refactored `src/js/widgets/note.js` to return only the textarea body, centralized pin/delete handlers in `src/js/handlers/handlers.note.js`, and added widget-title controllers in `src/js/controllers.js` with event bindings in `src/js/events.js`.
- Normalized multi-whitespace in `CommandDashboard.widgets.meta.setTitle`, guarded autosize calls in `src/js/render.js`, and added CSS rules in `src/styles.css` for `.widget`, `.widget-header`, and `.widget-title`.

### Testing
- Ran the unit harness with `node tests/basic.test.js`, which executed 3 tests and printed: `Ran 3 basic widget tests.`, indicating success.
- No additional automated browser/UI tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f9b31b03483339f3218d008654613)