### PR TITLE
Move note autosize behavior into note widget

### DIFF
--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -90,10 +90,11 @@ CommandDashboard.controllers.onDashboardInput = function onDashboardInput(event)
     widget.data ??= {};
     widget.data.text = target.value;
 
-  // immediate UX
-    CommandDashboard.render.autosizeTextarea(target);
+    // immediate UX
+    const noteApi = CommandDashboard.widgets.get?.("note");
+    noteApi?.autosizeTextarea?.(target);
 
-  // delayed persistence
+    // delayed persistence
     CommandDashboard.store.scheduleSave(250);
 };
 

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -12,11 +12,6 @@ let _dashboard = null;
 let _headerTitle = null;
 let _clearNotesBtn = null;
 
-function _autosizeTextarea(textarea) {
-    textarea.style.height = "auto";
-    textarea.style.height = `${textarea.scrollHeight}px`;
-}
-
 function _createEmptyMessage() {
     const msg = document.createElement("div");
     msg.textContent = "No widgets yet — click + Note to add one.";
@@ -30,20 +25,7 @@ function _focusNote(widgetId) {
     if(note) note.focus();
 }
 
-function _wireAutosizeOnInput() {
-    if (!_dashboard) return;
-
-    _dashboard.addEventListener("input", (event) => {
-        const target = event.target;
-        if (!(target instanceof HTMLTextAreaElement)) return;
-        if (!target.classList.contains("note-text")) return;
-    
-      _autosizeTextarea(target);
-  });
-}
-
 CommandDashboard.render.focusNote = _focusNote;
-CommandDashboard.render.wireAutosizeOnInput = _wireAutosizeOnInput;
 
 /**
  * Call once from app.js after you have the elements.
@@ -53,7 +35,6 @@ CommandDashboard.render.init = function initRender({ dashboard, headerTitle, cle
     _headerTitle = headerTitle;
     _clearNotesBtn = clearNotesBtn;
 
-    _wireAutosizeOnInput();
 };
 
 /**
@@ -81,10 +62,5 @@ CommandDashboard.render.renderApp = function renderApp(state) {
         if (!widgetElement) continue;
     
         _dashboard.appendChild(widgetElement);
-        const textarea = widgetElement.querySelector?.("textarea.note-text");
-
-        _autosizeTextarea(textarea);
     }
 };
-
-CommandDashboard.render.autosizeTextarea = _autosizeTextarea;

--- a/src/js/widgets/note.js
+++ b/src/js/widgets/note.js
@@ -3,6 +3,12 @@ window.CommandDashboard = window.CommandDashboard ?? {};
 CommandDashboard.widgets = CommandDashboard.widgets ?? {};
 console.log("note widget registry loaded");
 
+function _autosizeTextarea(textarea) {
+    if (!(textarea instanceof HTMLTextAreaElement)) return;
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+}
+
 function _createNoteCard(widget) {
     const noteCard = document.createElement("div");
     noteCard.className = "note-card";
@@ -39,6 +45,7 @@ function _createNoteCard(widget) {
     textarea.value = widget.data?.text ?? "";
     textarea.placeholder = "Write something ...";
     textarea.dataset.widgetId = widget.id;
+    _autosizeTextarea(textarea);
 
     noteCard.appendChild(header);
     noteCard.appendChild(textarea);
@@ -54,4 +61,5 @@ CommandDashboard.widgets.register("note", {
         meta: { pinned: false }
     }),
     render: (widget) => _createNoteCard(widget),
+    autosizeTextarea: _autosizeTextarea,
 });


### PR DESCRIPTION
### Motivation
- `render.js` contained textarea autosize logic that targeted the `note` widget, violating widget-agnostic separation of concerns.
- Autosizing is specific to the `note` widget and should be owned by that widget to keep the render layer generic.
- Expose the autosize function via the widget API so other modules can invoke it without coupling to `render`.

### Description
- Removed `_autosizeTextarea` and note-specific autosize wiring from `src/js/render.js` to keep rendering widget-agnostic.
- Added `_autosizeTextarea` implementation inside `src/js/widgets/note.js` and invoked it during note element creation.
- Exported the autosize function on the note widget API as `autosizeTextarea` so consumers can call it (`CommandDashboard.widgets.get("note").autosizeTextarea`).
- Updated `src/js/controllers.js` to call the note widget API for immediate UX autosizing instead of `CommandDashboard.render.autosizeTextarea`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fb1312fec8333ba0b69dea1102153)