### PR TITLE
Add JSDoc annotations across dashboard modules

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -11,6 +11,7 @@ if (!CommandDashboard.io) throw new Error("i/o not loaded");
 if (!CommandDashboard.toast) throw new Error("toast not loaded");
 if (!CommandDashboard.store) throw new Error("store not loaded");
 
+/** @type {{dashboard: HTMLElement, addNoteBtn: HTMLButtonElement, headerTitle: HTMLElement, clearNotesBtn: HTMLButtonElement, exportBtn: HTMLButtonElement, importBtn: HTMLButtonElement, importFileInput: HTMLInputElement}} */
 const ui = {
     dashboard: CommandDashboard.dom.mustBe(CommandDashboard.dom.mustGetElementById("dashboard"), HTMLElement, "#dashboard"),
     addNoteBtn: CommandDashboard.dom.mustBe(CommandDashboard.dom.mustGetElementById("addNoteBtn"), HTMLButtonElement, "#addNoteBtn"),

--- a/src/js/controllers.js
+++ b/src/js/controllers.js
@@ -4,11 +4,20 @@ CommandDashboard.controllers = CommandDashboard.controllers ?? {};
 console.log("Loaded controllers");
 
 
+/**
+ * Opens the file picker for importing state.
+ * @param {MouseEvent} event
+ */
 CommandDashboard.controllers.onImportClick = function onImportClick(event) {
     event.preventDefault();
     CommandDashboard.io.openImportPicker();
 };
 
+/**
+ * Handles JSON file selection and imports state.
+ * @param {Event} event
+ * @returns {Promise<void>}
+ */
 CommandDashboard.controllers.onImportFileChange = async function onImportFileChange(event) {
     const input = event.currentTarget;
     if (!(input instanceof HTMLInputElement)) return;
@@ -49,6 +58,10 @@ CommandDashboard.controllers.onImportFileChange = async function onImportFileCha
     }
 };
 
+/**
+ * Exports the current application state to JSON.
+ * @param {MouseEvent} event
+ */
 CommandDashboard.controllers.onExportClick = function onExportClick(event) {
     event.preventDefault();
 
@@ -76,6 +89,10 @@ CommandDashboard.controllers.onExportClick = function onExportClick(event) {
 };
 
 // Debounce to save dashboard/widget input
+/**
+ * Handles input events within the dashboard for notes and titles.
+ * @param {Event} event
+ */
 CommandDashboard.controllers.onDashboardInput = function onDashboardInput(event) {
     const target = event.target;
     if (target instanceof HTMLTextAreaElement && target.classList.contains("note-text")) {
@@ -109,6 +126,10 @@ CommandDashboard.controllers.onDashboardInput = function onDashboardInput(event)
     CommandDashboard.store.scheduleSave(250);
 };
 
+/**
+ * Updates the dashboard title from the header input.
+ * @param {Event} event
+ */
 CommandDashboard.controllers.onTitleInput = function onTitleInput (event) {
     const headerTitle = event.currentTarget;
     if (!(headerTitle instanceof HTMLElement)) return;
@@ -118,6 +139,10 @@ CommandDashboard.controllers.onTitleInput = function onTitleInput (event) {
 };
 
 // Keep title a single line
+/**
+ * Prevents new lines in the header title.
+ * @param {KeyboardEvent} event
+ */
 CommandDashboard.controllers.onTitleKeyDown = function onTitleKeyDown(event) {
     if (event.key === "Enter") {
         event.preventDefault();
@@ -125,6 +150,10 @@ CommandDashboard.controllers.onTitleKeyDown = function onTitleKeyDown(event) {
     }
 };
 
+/**
+ * Prevents new lines in widget titles.
+ * @param {KeyboardEvent} event
+ */
 CommandDashboard.controllers.onWidgetTitleKeyDown = function onWidgetTitleKeyDown(event) {
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
@@ -136,6 +165,10 @@ CommandDashboard.controllers.onWidgetTitleKeyDown = function onWidgetTitleKeyDow
     }
 };
 
+/**
+ * Restores the stored widget title on focus out.
+ * @param {FocusEvent} event
+ */
 CommandDashboard.controllers.onWidgetTitleFocusOut = function onWidgetTitleFocusOut(event) {
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
@@ -159,6 +192,9 @@ CommandDashboard.controllers.onWidgetTitleFocusOut = function onWidgetTitleFocus
 };
 
 // Add widget
+/**
+ * Adds a new note widget.
+ */
 CommandDashboard.controllers.onAddNote = function onAddNote() {
     const noteApi = CommandDashboard.widgets.get?.("note");
     const newWidget = noteApi.create();
@@ -171,6 +207,10 @@ CommandDashboard.controllers.onAddNote = function onAddNote() {
 };
 
 // Widget button action dispatcher
+/**
+ * Dispatches widget button actions within the dashboard.
+ * @param {MouseEvent} event
+ */
 CommandDashboard.controllers.onDashboardClick = function onDashboardClick(event) {
     const btn = event.target.closest("button");
     if (!btn) return;
@@ -191,6 +231,10 @@ CommandDashboard.controllers.onDashboardClick = function onDashboardClick(event)
 };
 
 // Clear all widgets
+/**
+ * Clears all notes with optional undo.
+ * @param {MouseEvent} event
+ */
 CommandDashboard.controllers.onClearNotes = function onClearNotes(event) {
     event.preventDefault();
 

--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -3,12 +3,25 @@ CommandDashboard.dom = CommandDashboard.dom ?? {};
 console.log("DOM guards loaded");
 
 CommandDashboard.dom = (function () {
+    /**
+     * Fetches a required element by ID.
+     * @param {string} id
+     * @returns {HTMLElement}
+     */
     function mustGetElementById(id) {
         const el = document.getElementById(id);
         if (!el) throw new Error(`Missing required element: #${id}`);
         return el;
     }
 
+    /**
+     * Ensures a value is an instance of the expected constructor.
+     * @template T
+     * @param {unknown} el
+     * @param {new (...args: any[]) => T} ctor
+     * @param {string} name
+     * @returns {T}
+     */
     function mustBe(el, ctor, name) {
         if (!(el instanceof ctor)) throw new Error(`${name} is not a ${ctor.name}`);
         return el;

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -3,6 +3,10 @@ window.CommandDashboard = window.CommandDashboard ?? {};
 CommandDashboard.events = CommandDashboard.events ?? {};
 console.log("Loaded event listeners");
 
+/**
+ * Binds DOM event handlers for the dashboard UI.
+ * @param {{dashboard: HTMLElement, addNoteBtn: HTMLButtonElement, headerTitle: HTMLElement, clearNotesBtn: HTMLButtonElement, exportBtn: HTMLButtonElement, importBtn: HTMLButtonElement, importFileInput: HTMLInputElement}} ui
+ */
 CommandDashboard.events.bind = function bindEvents(ui) {
     const controllers = CommandDashboard.controllers;
 

--- a/src/js/handlers/handlers.note.js
+++ b/src/js/handlers/handlers.note.js
@@ -3,6 +3,10 @@ window.CommandDashboard = window.CommandDashboard ?? {};
 CommandDashboard.handlers = CommandDashboard.handlers ?? {};
 console.log("Note widget handlers loaded");
 
+/**
+ * Deletes a widget and shows an undo toast.
+ * @param {string} widgetId
+ */
 function _deleteWidget(widgetId) {
     if (!widgetId) return;
 
@@ -35,6 +39,11 @@ function _deleteWidget(widgetId) {
     CommandDashboard.toast.show("Widget Deleted", "info", 5000, undoAction);
 }
 
+/**
+ * Pins or unpins a widget and reorders it within the list.
+ * @param {string} widgetId
+ * @param {boolean} pin
+ */
 function _pinWidget(widgetId, pin) {
     if (!widgetId) return;
 
@@ -67,10 +76,18 @@ function _pinWidget(widgetId, pin) {
     CommandDashboard.widgets.note.focusNote(widgetId);
 }
 
+/**
+ * Handler for deleting a widget from chrome controls.
+ * @param {{widgetId: string}} payload
+ */
 CommandDashboard.handlers["widget-delete"] = function widgetDeleteHandler({ widgetId }) {
     _deleteWidget(widgetId);
 };
 
+/**
+ * Handler for toggling widget pin state.
+ * @param {{widgetId: string}} payload
+ */
 CommandDashboard.handlers["widget-pin-toggle"] = function widgetPinToggleHandler({ widgetId }) {
     if (!widgetId) return;
 
@@ -81,14 +98,26 @@ CommandDashboard.handlers["widget-pin-toggle"] = function widgetPinToggleHandler
     _pinWidget(widgetId, !pinned);
 };
 
+/**
+ * Handler for deleting a note widget.
+ * @param {{widgetId: string}} payload
+ */
 CommandDashboard.handlers["note-delete"] = function noteDeleteHandler({ widgetId }) {
     _deleteWidget(widgetId);
 };
 
+/**
+ * Handler for pinning a note widget.
+ * @param {{widgetId: string}} payload
+ */
 CommandDashboard.handlers["note-pin"] = function notePinHandler({ widgetId }) {
     _pinWidget(widgetId, true);
 };
 
+/**
+ * Handler for unpinning a note widget.
+ * @param {{widgetId: string}} payload
+ */
 CommandDashboard.handlers["note-unpin"] = function noteUnpinHandler({ widgetId }) {
     _pinWidget(widgetId, false);
 };

--- a/src/js/io.js
+++ b/src/js/io.js
@@ -5,6 +5,10 @@ console.log("Widget I/O loaded");
 
 // Helpers
 
+/**
+ * Creates a filename-safe timestamp.
+ * @returns {string}
+ */
 CommandDashboard.io._createTimestamp = function createTimestamp() {
     const currentDateTime = new Date();
     return ( currentDateTime.getFullYear() + "-" +
@@ -16,6 +20,12 @@ CommandDashboard.io._createTimestamp = function createTimestamp() {
     );
 }
 
+/**
+ * Exports state to a downloadable JSON file.
+ * @param {AppState} state
+ * @param {string} [filenamePrefix]
+ * @returns {string}
+ */
 CommandDashboard.io.exportStateToJson = function exportStateToJson(state, filenamePrefix = "command-dashboard") {
     const json = JSON.stringify(state, null, 2);
     const blob = new Blob([json], {type: "application/json"});
@@ -36,6 +46,10 @@ CommandDashboard.io.exportStateToJson = function exportStateToJson(state, filena
     return anchorElement.download;
 };
 
+/**
+ * Creates or returns the hidden import input element.
+ * @returns {HTMLInputElement}
+ */
 CommandDashboard.io.getImportInput = function getImportInput() {
     if (CommandDashboard.io._importFileInput) return CommandDashboard.io._importFileInput;
 
@@ -49,6 +63,9 @@ CommandDashboard.io.getImportInput = function getImportInput() {
     return input;
 };
 
+/**
+ * Opens the import file picker dialog.
+ */
 CommandDashboard.io.openImportPicker = function openImportPicker() {
     const importFileInput = CommandDashboard.io.getImportInput();
     importFileInput.value = "";

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -12,6 +12,10 @@ let _dashboard = null;
 let _headerTitle = null;
 let _clearNotesBtn = null;
 
+/**
+ * Creates the empty-state message element.
+ * @returns {HTMLDivElement}
+ */
 function _createEmptyMessage() {
     const msg = document.createElement("div");
     msg.textContent = "No widgets yet — click + Note to add one.";
@@ -22,6 +26,10 @@ function _createEmptyMessage() {
 /**
  * Call once from app.js after you have the elements.
  */
+/**
+ * Initializes the renderer with cached DOM nodes.
+ * @param {{dashboard: HTMLElement, headerTitle: HTMLElement, clearNotesBtn: HTMLButtonElement}} params
+ */
 CommandDashboard.render.init = function initRender({ dashboard, headerTitle, clearNotesBtn }) {
     _dashboard = dashboard;
     _headerTitle = headerTitle;
@@ -30,6 +38,10 @@ CommandDashboard.render.init = function initRender({ dashboard, headerTitle, cle
 
 /**
  * Renders the full UI from state with any stored widgets
+ */
+/**
+ * Renders the full UI from the provided state.
+ * @param {AppState} state
  */
 CommandDashboard.render.renderApp = function renderApp(state) {
     if (!_dashboard || !_headerTitle || !_clearNotesBtn) {

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -1,4 +1,27 @@
 // state.js
+/**
+ * @typedef {Object} WidgetMeta
+ * @property {boolean} [pinned]
+ * @property {string} [title]
+ * @property {string} [createdAt]
+ */
+
+/**
+ * @typedef {Object} Widget
+ * @property {string} id
+ * @property {string} type
+ * @property {Record<string, unknown>} [data]
+ * @property {WidgetMeta} [meta]
+ */
+
+/**
+ * @typedef {Object} AppState
+ * @property {string} title
+ * @property {number} schemaVersion
+ * @property {Widget[]} widgets
+ */
+
+/** @type {AppState} */
 window.appState = window.appState ?? {
     title: "Name your Dashboard:",
     schemaVersion: 1,

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -6,6 +6,10 @@ console.log("Loaded storage");
 
 const STORAGE_KEY = "command-dashboard-state";
 
+/**
+ * Loads the persisted state from local storage.
+ * @returns {AppState | null}
+ */
 CommandDashboard.storage.loadState = function loadState() {
     const serializedSavedState = localStorage.getItem(STORAGE_KEY);
     if (serializedSavedState === null) {
@@ -23,6 +27,10 @@ CommandDashboard.storage.loadState = function loadState() {
     }
 }
 
+/**
+ * Saves the current state to local storage.
+ * @param {AppState} state
+ */
 CommandDashboard.storage.saveState = function saveState(state) {
     const savedState = JSON.stringify(state);
     localStorage.setItem(STORAGE_KEY, savedState);

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -10,12 +10,20 @@ let _render = null;
 
 let _saveTimerId = null;
 
+/**
+ * Initializes the store with persistence and render handlers.
+ * @param {{load: () => AppState | null, save: (state: AppState) => void, render: (state: AppState) => void}} params
+ */
 CommandDashboard.store.init = function initStore({load, save, render}) {
     _load = load;
     _save = save;
     _render = render;
 };
 
+/**
+ * Loads persisted state into memory and normalizes widget metadata.
+ * @returns {boolean}
+ */
 CommandDashboard.store.hydrateFromStorage = function hydrateFromStorage() {
     if (typeof _load !== "function" || typeof _save !== "function" || typeof _render !== "function") {
         throw new Error("store.init(...) not called");
@@ -44,14 +52,25 @@ CommandDashboard.store.hydrateFromStorage = function hydrateFromStorage() {
     return true;
 };
 
+/**
+ * Returns the current app state reference.
+ * @returns {AppState}
+ */
 CommandDashboard.store.getState = function getState() {
     return window.appState;
 };
 
+/**
+ * Saves the current app state immediately.
+ */
 CommandDashboard.store.saveNow = function saveNow() {
     _save(window.appState);
 };
 
+/**
+ * Applies a mutation and persists + re-renders.
+ * @param {(state: AppState) => void} mutatorFn
+ */
 CommandDashboard.store.apply = function apply(mutatorFn) {
     if (typeof mutatorFn !== "function") {
         throw new Error("mutatorFn must be a function");
@@ -62,6 +81,10 @@ CommandDashboard.store.apply = function apply(mutatorFn) {
     _render(window.appState);
 };
 
+/**
+ * Replaces state with a new, validated state.
+ * @param {AppState} newState
+ */
 CommandDashboard.store.replace = function replace(newState) {
     if (!CommandDashboard.store.isValidState(newState)) {
         throw new Error("INVALID_STATE");
@@ -72,6 +95,10 @@ CommandDashboard.store.replace = function replace(newState) {
     _render(window.appState);
 };
 
+/**
+ * Schedules a debounced save.
+ * @param {number} [delayMs=250]
+ */
 CommandDashboard.store.scheduleSave = function scheduleSave(delayMs = 250) {
     if (typeof _save !== "function") throw new Error("store.init(...) not called");
 
@@ -82,6 +109,11 @@ CommandDashboard.store.scheduleSave = function scheduleSave(delayMs = 250) {
     }, delayMs);
 };
 
+/**
+ * Validates the state shape.
+ * @param {unknown} state
+ * @returns {state is AppState}
+ */
 CommandDashboard.store.isValidState = function isValidState(state) {
     if (!state || typeof state !== "object") return false;
     if (typeof state.schemaVersion !== "number") return false;

--- a/src/js/toast.js
+++ b/src/js/toast.js
@@ -12,6 +12,17 @@ const toastHost = CommandDashboard.dom.mustBe(CommandDashboard.dom.mustGetElemen
 const VALID_TYPES = new Set(["info", "success", "error"]);
 const MAX_TOASTS = 3;
 
+/**
+ * @typedef {Object} ToastActionOptions
+ * @property {string} [actionText]
+ * @property {() => void} [onAction]
+ * @property {boolean} [sticky]
+ */
+
+/**
+ * Dismisses a toast element with animation.
+ * @param {HTMLElement} toastEl
+ */
 function _dismissToast(toastEl) {
   if (!toastEl || toastEl._isRemoving) return;
   toastEl._isRemoving = true;
@@ -25,6 +36,13 @@ function _dismissToast(toastEl) {
   toastEl.addEventListener("animationend", () => toastEl.remove(), { once: true });
 }
 
+/**
+ * Displays a toast notification.
+ * @param {string} message
+ * @param {"info" | "success" | "error"} [type="info"]
+ * @param {number} [durationMs=3000]
+ * @param {ToastActionOptions | null} [options=null]
+ */
 CommandDashboard.toast.show = function showToast(
       message,
       type = "info",

--- a/src/js/widgets/chrome.js
+++ b/src/js/widgets/chrome.js
@@ -4,6 +4,11 @@ CommandDashboard.widgets = CommandDashboard.widgets ?? {};
 CommandDashboard.widgets.chrome = CommandDashboard.widgets.chrome ?? {};
 console.log("Widget chrome loaded");
 
+/**
+ * Creates the chrome header for a widget.
+ * @param {Widget} widget
+ * @returns {HTMLDivElement}
+ */
 function _createHeader(widget) {
     const header = document.createElement("div");
     header.className = "widget-header";
@@ -49,6 +54,11 @@ function _createHeader(widget) {
     return header;
 }
 
+/**
+ * Creates chrome wrapper elements for a widget.
+ * @param {Widget} widget
+ * @returns {{outer: HTMLDivElement, body: HTMLDivElement}}
+ */
 CommandDashboard.widgets.chrome.create = function createWidgetChrome(widget) {
     const outer = document.createElement("div");
     outer.className = "widget";

--- a/src/js/widgets/note.js
+++ b/src/js/widgets/note.js
@@ -4,17 +4,30 @@ CommandDashboard.widgets = CommandDashboard.widgets ?? {};
 CommandDashboard.widgets.note = CommandDashboard.widgets.note ?? {};
 console.log("note widget registry loaded");
 
+/**
+ * Automatically grows a textarea to fit content.
+ * @param {HTMLTextAreaElement} textarea
+ */
 function _autosizeTextarea(textarea) {
     textarea.style.height = "auto";
     textarea.style.height = `${textarea.scrollHeight}px`;
 }
 
+/**
+ * Focuses a note textarea by widget id.
+ * @param {string} widgetId
+ */
 function _focusNote(widgetId) {
     if (!widgetId) return;
     const note = document.querySelector(`textarea.note-text[data-widget-id="${widgetId}"]`);
     if (note) note.focus();
 }
 
+/**
+ * Creates the note widget body element.
+ * @param {Widget} widget
+ * @returns {HTMLTextAreaElement}
+ */
 function _createNoteBody(widget) {
     const textarea = document.createElement("textarea");
     textarea.className = "note-text";
@@ -27,12 +40,21 @@ function _createNoteBody(widget) {
 }
 
 CommandDashboard.widgets.register("note", {
+    /**
+     * Creates a new note widget definition.
+     * @returns {Widget}
+     */
     create: () => ({
         id: "w_" + Date.now() + "_" + Math.random().toString(36).slice(2, 6),
         type: "note",
         data: { text: "" },
         meta: { pinned: false }
     }),
+    /**
+     * Renders a note widget.
+     * @param {Widget} widget
+     * @returns {HTMLTextAreaElement}
+     */
     render: (widget) => _createNoteBody(widget),
 });
 

--- a/src/js/widgets/registry.js
+++ b/src/js/widgets/registry.js
@@ -3,21 +3,25 @@ window.CommandDashboard = window.CommandDashboard ?? {};
 CommandDashboard.widgets = CommandDashboard.widgets ?? {};
 console.log("Widget registry loaded");
 
+/** @type {Map<string, {render: (widget: Widget) => HTMLElement, create?: () => Widget}>} */
 const _renderersByType = new Map();
 
 /**
- * Register a widget type.
- * type: e.g. "note"
- * api: { render(widget) -> HTMLElement }
- * @type string, function
+ * Registers a widget type.
+ * @param {string} type
+ * @param {{render: (widget: Widget) => HTMLElement, create?: () => Widget}} api
  */
-
 CommandDashboard.widgets.register = function register(type, api) {
     if (!type || typeof type !== "string") throw new Error("register: type required");
     if (!api || typeof api.render !== "function") throw new Error(`register(${type}): api.render required`);
     _renderersByType.set(type, api);
 };
 
+/**
+ * Renders a widget with chrome when available.
+ * @param {Widget} widget
+ * @returns {HTMLElement | null}
+ */
 CommandDashboard.widgets.renderWidget = function renderWidget(widget) {
     const type = widget?.type;
     const api = _renderersByType.get(type);
@@ -37,6 +41,11 @@ CommandDashboard.widgets.renderWidget = function renderWidget(widget) {
     return outer ?? content;
 }
 
+/**
+ * Retrieves a widget API by type.
+ * @param {string} type
+ * @returns {{render: (widget: Widget) => HTMLElement, create?: () => Widget} | null}
+ */
 CommandDashboard.widgets.get = function get(type) {
     return _renderersByType.get(type) ?? null;
 };

--- a/src/js/widgets/widgetMeta.js
+++ b/src/js/widgets/widgetMeta.js
@@ -4,12 +4,22 @@ CommandDashboard.widgets = CommandDashboard.widgets ?? {};
 CommandDashboard.widgets.meta = CommandDashboard.widgets.meta ?? {};
 console.log("Widget meta helpers loaded");
 
+/**
+ * Ensures the widget has a meta object.
+ * @param {Widget} widget
+ * @returns {WidgetMeta | null}
+ */
 function _ensureMeta(widget) {
     if (!widget || typeof widget !== "object") return null;
     if (!widget.meta || typeof widget.meta !== "object") widget.meta = {};
     return widget.meta;
 }
 
+/**
+ * Gets the pinned state for a widget.
+ * @param {Widget} widget
+ * @returns {boolean}
+ */
 CommandDashboard.widgets.meta.getPinned = function getPinned(widget) {
     if (widget?.meta && Object.prototype.hasOwnProperty.call(widget.meta, "pinned")) {
         return !!widget.meta.pinned;
@@ -17,12 +27,22 @@ CommandDashboard.widgets.meta.getPinned = function getPinned(widget) {
     return !!widget?.data?.pinned;
 };
 
+/**
+ * Sets the pinned state for a widget.
+ * @param {Widget} widget
+ * @param {boolean} pinned
+ */
 CommandDashboard.widgets.meta.setPinned = function setPinned(widget, pinned) {
     const meta = _ensureMeta(widget);
     if (!meta) return;
     meta.pinned = !!pinned;
 };
 
+/**
+ * Returns the stored widget title.
+ * @param {Widget} widget
+ * @returns {string}
+ */
 CommandDashboard.widgets.meta.getTitle = function getTitle(widget) {
     if (widget?.meta && Object.prototype.hasOwnProperty.call(widget.meta, "title")) {
         return String(widget.meta.title ?? "");
@@ -30,6 +50,11 @@ CommandDashboard.widgets.meta.getTitle = function getTitle(widget) {
     return "";
 };
 
+/**
+ * Sets the widget title, normalizing whitespace.
+ * @param {Widget} widget
+ * @param {string} title
+ */
 CommandDashboard.widgets.meta.setTitle = function setTitle(widget, title) {
     const meta = _ensureMeta(widget);
     if (!meta) return;
@@ -37,6 +62,11 @@ CommandDashboard.widgets.meta.setTitle = function setTitle(widget, title) {
     meta.title = normalized;
 };
 
+/**
+ * Returns a valid ISO created-at timestamp if present.
+ * @param {Widget} widget
+ * @returns {string}
+ */
 CommandDashboard.widgets.meta.getCreatedAt = function getCreatedAt(widget) {
     const rawCreatedAt = widget?.meta?.createdAt;
     if (typeof rawCreatedAt !== "string") return "";
@@ -47,6 +77,11 @@ CommandDashboard.widgets.meta.getCreatedAt = function getCreatedAt(widget) {
     return rawCreatedAt;
 };
 
+/**
+ * Sets the widget created-at timestamp.
+ * @param {Widget} widget
+ * @param {string} isoString
+ */
 CommandDashboard.widgets.meta.setCreatedAt = function setCreatedAt(widget, isoString) {
     const meta = CommandDashboard.widgets.meta.ensureMeta(widget);
     if (!meta) return;
@@ -57,6 +92,11 @@ CommandDashboard.widgets.meta.setCreatedAt = function setCreatedAt(widget, isoSt
     meta.createdAt = isoString;
 };
 
+/**
+ * Ensures the widget has a created-at timestamp.
+ * @param {Widget} widget
+ * @returns {string}
+ */
 CommandDashboard.widgets.meta.ensureCreatedAt = function ensureCreatedAt(widget) {
     const meta = CommandDashboard.widgets.meta.ensureMeta(widget);
     if (!meta) return "";


### PR DESCRIPTION
### Motivation

- Provide consistent JSDoc and inline typedefs to improve editor/IDE type hints and code clarity.
- Introduce shared `AppState`/`Widget` typedefs so state shape is explicitly documented and validated.
- Document key public APIs (`store`, `render`, `io`, `storage`, `controllers`, `widgets`) to reduce runtime errors and aid maintenance.
- Standardize annotations for widget helpers, chrome, meta, handlers, and toast internals for a unified developer experience.

### Description

- Add `WidgetMeta`, `Widget`, and `AppState` typedefs to `src/js/state.js` and annotate UI wiring in `src/js/app.js` with a typed `ui` object.
- Add JSDoc to controller functions in `src/js/controllers.js` and to event binding in `src/js/events.js` to document parameters and behavior.
- Annotate store/persistence/render/I/O functions in `src/js/store.js`, `src/js/storage.js`, `src/js/render.js`, and `src/js/io.js` including `init`, `hydrateFromStorage`, `apply`, `replace`, `isValidState`, `exportStateToJson`, and import helpers.
- Add JSDoc and small type hints across widget modules (`registry.js`, `widgetMeta.js`, `note.js`, `chrome.js`) and handlers/toast (`handlers.note.js`, `toast.js`) including typed maps, param/return annotations, and helper docs.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960779a634c83339ddd0828a5a4a689)